### PR TITLE
Fix 3D text scrolling behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 import { Canvas, useFrame } from "@react-three/fiber"
-import { ScrollControls, useScroll, Text, Stars, Sparkles, Environment, Scroll } from "@react-three/drei"
+import { ScrollControls, useScroll, Text, Stars, Sparkles, Environment } from "@react-three/drei"
 import { useRef, useState, useEffect, useMemo } from "react"
 import type { Group } from "three"
 import * as THREE from "three"
@@ -309,9 +309,7 @@ export default function SpaceScrollLP() {
         <Environment preset="night" />
 
         <ScrollControls pages={12} damping={0.15}>
-          <Scroll>
-            <Scene />
-          </Scroll>
+          <Scene />
         </ScrollControls>
       </Canvas>
     </div>


### PR DESCRIPTION
## Summary
- keep text centered in space scroll landing page
- remove default Scroll component that shifted group on Y

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68400e2562248321821a358f99cde555