### PR TITLE
Fix 3D text scrolling behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,13 +6,6 @@ import { ScrollControls, useScroll, Text, Stars, Sparkles, Environment } from "@
 import { useRef, useState, useEffect, useMemo } from "react"
 import type { Group } from "three"
 import * as THREE from "three"
-// import { HeroSection } from "@/components/lp/HeroSection"
-// import { SolutionSection } from "@/components/lp/SolutionSection"
-// import { PersonaSection } from "@/components/lp/PersonaSection"
-// import { AchievementSection } from "@/components/lp/AchievementSection"
-// import { ScrollExperienceSection } from "@/components/lp/ScrollExperienceSection"
-// import { FAQSection } from "@/components/lp/FAQSection"
-// import { CTASection } from "@/components/lp/CTASection"
 
 // カメラに近づく処理だけ
 function CameraRig({ children }: { children: React.ReactNode }) {
@@ -308,6 +301,7 @@ export default function SpaceScrollLP() {
         <Sparkles count={150} scale={[100, 100, 100]} size={6} speed={0.5} />
         <Environment preset="night" />
 
+        {/* The Drei Scroll element is omitted to keep sections vertically centered */}
         <ScrollControls pages={12} damping={0.15}>
           <Scene />
         </ScrollControls>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 import { Canvas, useFrame } from "@react-three/fiber"
-import { ScrollControls, useScroll, Text, Stars, Sparkles, Environment, Scroll } from "@react-three/drei"
+import { ScrollControls, useScroll, Text, Stars, Sparkles, Environment } from "@react-three/drei"
 import { useRef, useState, useEffect, useMemo } from "react"
 import type { Group } from "three"
 import * as THREE from "three"
@@ -309,9 +309,7 @@ export default function SpaceScrollLP() {
         <Environment preset="night" />
 
         <ScrollControls pages={12} damping={0.15}>
-          <Scroll>
-            <Scene />
-          </Scroll>
+          <Scene />
         </ScrollControls>
       </Canvas>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { Canvas, useFrame } from "@react-three/fiber"
 import { ScrollControls, useScroll, Text, Stars, Sparkles, Environment } from "@react-three/drei"
+import { FixedScroll } from "@/components/FixedScroll"
 import { useRef, useState, useEffect, useMemo } from "react"
 import type { Group } from "three"
 import * as THREE from "three"
@@ -301,9 +302,12 @@ export default function SpaceScrollLP() {
         <Sparkles count={150} scale={[100, 100, 100]} size={6} speed={0.5} />
         <Environment preset="night" />
 
-        {/* The Drei Scroll element is omitted to keep sections vertically centered */}
+        {/* Use a custom scroll wrapper to keep sections centered while
+            still allowing depth-based scrolling */}
         <ScrollControls pages={12} damping={0.15}>
-          <Scene />
+          <FixedScroll>
+            <Scene />
+          </FixedScroll>
         </ScrollControls>
       </Canvas>
     </div>

--- a/components/FixedScroll.tsx
+++ b/components/FixedScroll.tsx
@@ -1,0 +1,24 @@
+import { forwardRef, useRef, useImperativeHandle } from "react"
+import { useThree, useFrame } from "@react-three/fiber"
+import { useScroll } from "@react-three/drei"
+import type { Group } from "three"
+
+// Similar to Drei's <Scroll> but keeps content vertically centered
+export const FixedScroll = forwardRef<Group, { children: React.ReactNode }>(
+  function FixedScroll({ children }, ref) {
+    const group = useRef<Group>(null)
+    useImperativeHandle(ref, () => group.current as Group)
+    const state = useScroll()
+    const { width } = useThree((s) => s.viewport)
+    useFrame(() => {
+      if (group.current) {
+        // Only apply horizontal translation (if used) but keep Y constant
+        group.current.position.x = state.horizontal
+          ? -width * (state.pages - 1) * state.offset
+          : 0
+        group.current.position.y = 0
+      }
+    })
+    return <group ref={group}>{children}</group>
+  }
+)


### PR DESCRIPTION
## Summary
- keep text centered in space scroll landing page
- remove default Scroll component that shifted group on Y

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68400e2562248321821a358f99cde555